### PR TITLE
Draft: Kamil #87 Users Management

### DIFF
--- a/cloud/.gitignore
+++ b/cloud/.gitignore
@@ -11,3 +11,5 @@ cdk.out
 # misc
 .DS_Store
 .env
+
+.idea/

--- a/cloud/lib/authentication/authCloudFormation.test.ts
+++ b/cloud/lib/authentication/authCloudFormation.test.ts
@@ -66,4 +66,14 @@ describe("Application stack [Auth]", () => {
       },
     });
   });
+
+  it("should have admin Cognito UserPools group", () => {
+    template.hasResource("AWS::Cognito::UserPoolGroup", {
+      Properties: {
+        UserPoolId: Match.objectLike({ Ref: expect.any }),
+        Description: "Admin group for users management",
+        GroupName: "admin",
+      },
+    });
+  });
 });

--- a/cloud/lib/authentication/cognitoUserPoolCdkConstruct.ts
+++ b/cloud/lib/authentication/cognitoUserPoolCdkConstruct.ts
@@ -11,6 +11,7 @@ interface CognitoUserPoolProps {
 export class CognitoUserPoolCdkConstruct extends Construct {
   public userPool: cognito.UserPool;
   public userPoolClient: cognito.UserPoolClient;
+  public userPoolGroups: cognito.CfnUserPoolGroup;
   constructor(
     scope: Construct,
     id: string,
@@ -53,6 +54,16 @@ export class CognitoUserPoolCdkConstruct extends Construct {
         ],
         preventUserExistenceErrors: true,
         userPool: this.userPool,
+      }
+    );
+
+    this.userPoolGroups = new cognito.CfnUserPoolGroup(
+      this,
+      `${envName}-AdminUserPoolGroup`,
+      {
+        userPoolId: this.userPool.userPoolId,
+        description: "Admin gruop for users management",
+        groupName: "admin",
       }
     );
 


### PR DESCRIPTION
Ticket: https://github.com/codeandpepper/janush/issues/87

Backend:
- [x] First of all you need to add administrators groups in Cognito (of course in IaC code).
- [ ] Add GraphQL endpoint (AWS AppSync service)
- [ ] Add GraphQL/AppSync query to get users from AWS Cognito (paginated, filtered as in designs)
- [ ] Add GraphQL/AppSync query to get groups from AWS Cognito
- [ ] Add GraphQL/AppSync mutation to be able to add new user to AWS Cognito
- [ ] Add GraphQL/AppSync mutation to add new group to AWS Cognito
- [ ] Add GraphQL/AppSync mutation to add user to existing group
- [ ] Add GraphQL/AppSync mutation to edit user
- [ ] Add GraphQL/AppSync mutation to edit group
- [ ] Add GraphQL/AppSync mutation to delete user
- [ ] Add GraphQL/AppSync mutation to delete group
- [ ] Add GraphQL/AppSync mutation to delete user from certain group
- [ ]  Add GraphQL/AppSync mutation to enable/disable user (it should enable disabled user and disable enabled user)

Frontend:
- [ ] Proceed according to the designs using GraphQL queries/mutation done via backend.